### PR TITLE
Fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,6 @@ version: 2
 updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: "develop"
     schedule:
       interval: "weekly"
     reviewers:
@@ -12,8 +10,6 @@ updates:
 
   # Maintain dependencies for go modules
   - package-ecosystem: "gomod"
-    directory: "/"
-    target-branch: "develop"
     schedule:
       interval: "weekly"
     reviewers:
@@ -22,8 +18,6 @@ updates:
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
-    directory: "/"
-    target-branch: "develop"
     schedule:
       interval: "weekly"
     reviewers:


### PR DESCRIPTION
* branch develop does not exist anymore, thus `target-branch` can be removed
* default directory is /, thus `directory` can be removed