### PR TITLE
Skip scale-down when nodegroup in backoff

### DIFF
--- a/controllers/scheduler_controller.go
+++ b/controllers/scheduler_controller.go
@@ -232,6 +232,13 @@ func (r *SchedulerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
+	// If the scale up is in state backoff, skip scale down. It is
+	// needed since in Backoff the cluster-autoscaler will not increase
+	// the cloudProviderTarget, e.g. : Backoff (ready=0 cloudProviderTarget=0).
+	if targetStatus.ScaleUp.Status == clusterautoscaler.ScaleUpBackoff {
+		down = 0
+	}
+
 	// List instances already deployed by this scheduler
 	instances := &corev1alpha1.InstanceList{}
 	if err := r.List(ctx, instances, client.InNamespace(req.Namespace), client.MatchingLabels(map[string]string{lblScheduler: req.Name})); err != nil {


### PR DESCRIPTION
This fixes the issue where kubestitute was downscaling when it was reading "Backoff (ready=0 cloudProviderTarget=0)". 